### PR TITLE
Documentando as dependências do curl no Ubuntu / Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # goCep
+
 Projeto em Golang para buscar dados do CEP e armazenar em cache 
+
 
 # Compilar
 
@@ -11,14 +13,24 @@ Além de ter o Go instalado no sistema operacional é necessário executar:
 	go get github.com/ryanuber/go-filecache
 	go build
 
+
+Se você está compilando este projeto no Ubuntu, ou no Debian, verifique se você possuí 
+uma das bibliotecas abaixo instaladas:
+
+* libcurl4-gnutls-dev
+* libcurl4-openssl-dev
+
+
 # Executar
 
 O binário chamado goCep será criado. Basta executá-lo e ele ficará ouvindo na porta 3000 por novas requisições
+
 
 # Testando
 Para rodar os tests, você pode executar:
 
 	go test
+
 
 # Uso
 


### PR DESCRIPTION
Ao compilar o projeto no Ubuntu, precisei instalar uma das bibliotecas que documentei abaixo, são dependências direta do `go-curl`.